### PR TITLE
Fix incorrect string validation for URL

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -1116,7 +1116,8 @@ class CookieJar {
   }
 
   setCookie(cookie, url, options, cb) {
-    validators.validate(validators.isNonEmptyString(url), cb, options);
+    validators.validate(validators.isUrlStringOrObject(url), cb, options);
+
     let err;
 
     if (validators.isFunction(url)) {
@@ -1314,7 +1315,8 @@ class CookieJar {
 
   // RFC6365 S5.4
   getCookies(url, options, cb) {
-    validators.validate(validators.isNonEmptyString(url), cb, url);
+    validators.validate(validators.isUrlStringOrObject(url), cb, url);
+
     const context = getCookieContext(url);
     if (validators.isFunction(options)) {
       cb = options;

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -59,6 +59,14 @@ function isInstanceStrict(data, prototype) {
   }
 }
 
+function isUrlStringOrObject(data) {
+  return (
+    isNonEmptyString(data) ||
+    isObject(data) || // TODO: Check for URL properties that are used.
+    isInstanceStrict(data, URL)
+  );
+}
+
 function isInteger(data) {
   return typeof data === "number" && data % 1 === 0;
 }
@@ -92,4 +100,5 @@ exports.isDate = isDate;
 exports.isEmptyString = isEmptyString;
 exports.isString = isString;
 exports.isObject = isObject;
+exports.isUrlStringOrObject = isUrlStringOrObject;
 exports.validate = validate;


### PR DESCRIPTION
The `getCookies` and `setCookie` functions can handle URL objects. They used to handle it in v4.0.0 but it seems since 4.1.1, validations were added which don't allow using URL object. PR https://github.com/salesforce/tough-cookie/pull/193

This change updates the validations to allow both string and object.